### PR TITLE
UTM-3954 use datatype definitions that allow codegen

### DIFF
--- a/TCL4 Data Management/utm-tcl4-data-collection.yaml
+++ b/TCL4 Data Management/utm-tcl4-data-collection.yaml
@@ -33,7 +33,9 @@ definitions:
           A UUID assingned by the reporting USS for this instance of
            OffNominalReport.
         type: string
-        format: uuidv4
+        format: uuid
+        minLength: 36
+        maxLength: 36
         example: 00000000-0000-4444-9988-bo55beefface
       reason_for_report:
         description: >-
@@ -128,7 +130,9 @@ definitions:
       gufi:
         description: GUFI of the operation that is the subject of this report.
         type: "string"
-        format: "uuidv4"
+        format: uuid
+        minLength: 36
+        maxLength: 36
         example: "00000000-0000-4444-9988-bo55beefface"
 
   LossOfUSS:
@@ -148,7 +152,10 @@ definitions:
         description: >-
           A UUID assigned by the reporting USS for this instance of
            USSNegotiation.
-        $ref: 'https://raw.githubusercontent.com/nasa/utm-apis/v4-draft/utm-domains/utm-domain-commons.yaml#/definitions/uuid'
+        type: string
+        format: uuid
+        minLength: 36
+        maxLength: 36
       uss_id:
         description: >-
           The reporting USSs ID as known by USS Network/FIMS.
@@ -182,7 +189,10 @@ definitions:
           during the time the USS was unaviable.
         type: array
         items:
-          $ref: 'https://raw.githubusercontent.com/nasa/utm-apis/v4-draft/utm-domains/utm-domain-commons.yaml#/definitions/uuid'
+          type: string
+          format: uuid
+          minLength: 36
+          maxLength: 36
   USSHandoff:
     description: >-
       An instance of this model should be submitted by each USS invovled in the
@@ -202,8 +212,10 @@ definitions:
         description: >-
           A UUID assigned by the reporting USS for this instance of
            USSHandoff.
-
-        $ref: 'https://raw.githubusercontent.com/nasa/utm-apis/v4-draft/utm-domains/utm-domain-commons.yaml#/definitions/uuid'
+        type: string
+        format: uuid
+        minLength: 36
+        maxLength: 36
       uss_id:
         description: >-
           The reporting USSs ID as known by USS Network/FIMS.
@@ -220,11 +232,17 @@ definitions:
       gufi:
         description: >-
           GUFI of the operation that is handed off.
-        $ref: 'https://raw.githubusercontent.com/nasa/utm-apis/v4-draft/utm-domains/utm-domain-commons.yaml#/definitions/uuid'
+        type: string
+        format: uuid
+        minLength: 36
+        maxLength: 36
       new_gufi:
         description: >-
           If a new gufi is generated after the handoff and is known, supply it here.
-        $ref: 'https://raw.githubusercontent.com/nasa/utm-apis/v4-draft/utm-domains/utm-domain-commons.yaml#/definitions/uuid'
+        type: string
+        format: uuid
+        minLength: 36
+        maxLength: 36
       operator:
         type: "string"
         minLength: 4
@@ -282,8 +300,10 @@ definitions:
         description: >-
           A UUID assigned by the reporting USS for this instance of
            USSNegotiation.
-
-        $ref: 'https://raw.githubusercontent.com/nasa/utm-apis/v4-draft/utm-domains/utm-domain-commons.yaml#/definitions/uuid'
+        type: string
+        format: uuid
+        minLength: 36
+        maxLength: 36
       reporter_gufi:
         description: >-
           GUFI of the operation managed by reporting USS involved in this
@@ -291,8 +311,10 @@ definitions:
 
           If GUFI does not exist, use 00000000-0000-4444-8888-000000000000.
           If GUFI was generated after the negotiation, include that value.
-
-        $ref: 'https://raw.githubusercontent.com/nasa/utm-apis/v4-draft/utm-domains/utm-domain-commons.yaml#/definitions/uuid'
+        type: string
+        format: uuid
+        minLength: 36
+        maxLength: 36
       other_gufi:
         description: >-
           GUFI of the other operation involved in this negotiation.
@@ -300,12 +322,18 @@ definitions:
           If GUFI does not exist, use 00000000-0000-4444-8888-000000000000.
           If GUFI was generated after the negotiation, include that value.
 
-        $ref: 'https://raw.githubusercontent.com/nasa/utm-apis/v4-draft/utm-domains/utm-domain-commons.yaml#/definitions/uuid'
+        type: string
+        format: uuid
+        minLength: 36
+        maxLength: 36
       message_ids:
         description: Complete list of UUIDs from each NegotiationMessage involved.
         type: "array"
         items:
-          $ref: 'https://raw.githubusercontent.com/nasa/utm-apis/v4-draft/utm-domains/utm-domain-commons.yaml#/definitions/uuid'
+          type: string
+          format: uuid
+          minLength: 36
+          maxLength: 36
       conflict_resolved:
         description: >-
           Were both operations allowed to complete their intended missions?
@@ -358,12 +386,18 @@ definitions:
       uss_operator_exchange_id:
         description: >-
           A UUID assigned by the reporting USS for this instance of USS2OperatorExchange.
-        $ref: 'https://raw.githubusercontent.com/nasa/utm-apis/v4-draft/utm-domains/utm-domain-commons.yaml#/definitions/uuid'
+        type: string
+        format: uuid
+        minLength: 36
+        maxLength: 36
       gufi:
         description: >-
           GUFI of the operation managed by reporting USS involved in this
           exchange.
-        $ref: 'https://raw.githubusercontent.com/nasa/utm-apis/v4-draft/utm-domains/utm-domain-commons.yaml#/definitions/uuid'
+        type: string
+        format: uuid
+        minLength: 36
+        maxLength: 36
       uss_id:
         description: >-
           The reporting USSs ID as known by USS Network/FIMS.
@@ -440,12 +474,20 @@ definitions:
       dr_occurence_id:
         description: >-
           A UUID assigned by the reporting USS for this instance of DynamicRestrictionOccurence.
-        $ref: 'https://raw.githubusercontent.com/nasa/utm-apis/v4-draft/utm-domains/utm-domain-commons.yaml#/definitions/uuid'
+        type: string
+        format: uuid
+        minLength: 36
+        maxLength: 36
+
       gufi:
         description: >-
           GUFI of the operation managed by reporting USS involved in this
           exchange.
-        $ref: 'https://raw.githubusercontent.com/nasa/utm-apis/v4-draft/utm-domains/utm-domain-commons.yaml#/definitions/uuid'
+
+        type: string
+        format: uuid
+        minLength: 36
+        maxLength: 36
       uss_id:
         description: >-
           The reporting USSs ID as known by USS Network/FIMS.
@@ -542,8 +584,10 @@ definitions:
       measurement_id:
         description: >-
           A UUID assigned by the reporting USS for this instance of USSExchange.
-        $ref: 'https://raw.githubusercontent.com/nasa/utm-apis/v4-draft/utm-domains/utm-domain-commons.yaml#/definitions/uuid'
-
+        type: string
+        format: uuid
+        minLength: 36
+        maxLength: 36
       event_id:
         description: >-
           A string provided by the owner of the overall test (likely NASA) that identifies the event within which this data exchange occurs. NASA will define a pattern for this for consistency across tests.
@@ -561,8 +605,10 @@ definitions:
           then just populate this field with one of the primary keys. As a best
           practice, choose the first one in the array as they were sent between
           USSs.
-        $ref: 'https://raw.githubusercontent.com/nasa/utm-apis/v4-draft/utm-domains/utm-domain-commons.yaml#/definitions/uuid'
-
+        type: string
+        format: uuid
+        minLength: 36
+        maxLength: 36
       exchanged_data_type:
         type: "string"
         enum:


### PR DESCRIPTION
UTM-3954 use datatype definitions that allow codegen 
UTM-3556 NUSS emits USSDataExchange and other data-collection models

Goals 
 1) NUSS emits TCL4 Sprint4 data collection models,  
 2) NUSS is fast runtime-debuggable 
 3) data collection swagger models are codegen'able

NUSS will emit USSDataExchange et all to a database table.  During an event we can  easily see data exchanges real time.  After the event we harvest from the table to a flat file for submission. 

Repositories:
UTM-DOCS  - data collection models suitable for code gen
UTM-COMMONS - create library of all data collection models.
DEPLOYMENT - auto build data collection model library
NUSS - emit data collection models 



