### PR TITLE
Add meta to dmp uss

### DIFF
--- a/TCL4 Data Management/utm-tcl4-data-collection.yaml
+++ b/TCL4 Data Management/utm-tcl4-data-collection.yaml
@@ -151,8 +151,8 @@ definitions:
       loss of USS services during a test.  If the USS is unavailable multiple times
       in a single test, one submission is sufficient.
     required:
-      - "uss_loss_id"
       - "metaDataDmpUss"
+      - "uss_loss_id"
       - "time_loss_detected"
       - "time_uss_completely_restored"
       - "method_loss_detected"
@@ -160,7 +160,6 @@ definitions:
     properties:
       metaDataDmpUss:
         $ref: 'https://raw.githubusercontent.com/nasa/utm-docs/add-meta-to-dmp-uss/TCL4%20Data%20Management/utm-tcl4-dmp-common.yaml#/definitions/metaDataDmpUss'
-
       uss_loss_id:
         description: >-
           A UUID assigned by the reporting USS for this instance of LossOfUSS
@@ -219,14 +218,16 @@ definitions:
       handoff of management of an operation.  These data are not captured within
       the USSNetwork.  These data may inform future procedures and standards.
     required:
-      - "handoff_id"
       - "metaDataDmpUss"
+      - "handoff_id"
       - "other_uss_id"
       - "operator"
       - "time_handoff_procedure_initiated"
       - "time_handoff_procedure_completed"
       - "gufi"
     properties:
+      metaDataDmpUss:
+        $ref: 'https://raw.githubusercontent.com/nasa/utm-docs/add-meta-to-dmp-uss/TCL4%20Data%20Management/utm-tcl4-dmp-common.yaml#/definitions/metaDataDmpUss'
       handoff_id:
         description: >-
           A UUID assigned by the reporting USS for this instance of
@@ -237,8 +238,6 @@ definitions:
         minLength: 36
         pattern: "^[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-4[0-9a-fA-F]{3}\\-[8-b][0-9a-fA-F]{3}\\-[0-9a-fA-F]{12}$"
         example: "00000000-0000-4444-8888-FEEDDEADBEEF"
-      metaDataDmpUss:
-        $ref: 'https://raw.githubusercontent.com/nasa/utm-docs/add-meta-to-dmp-uss/TCL4%20Data%20Management/utm-tcl4-dmp-common.yaml#/definitions/metaDataDmpUss'
       other_uss_id:
         description: >-
           The other USSs ID (on the other side of the handoff) as known by
@@ -318,8 +317,8 @@ definitions:
       the USSExchange model, since NegotiationMessages will be logged and supplied
       there.
     required:
-      - "negotiation_id"
       - "metaDataDmpUss"
+      - "negotiation_id"
       - "reporter_gufi"
       - "other_gufi"
       - "message_ids"
@@ -419,9 +418,9 @@ definitions:
       potential interactions between USS and Operator.  These data will
       be correlated with data captured via the USS Network.
     required:
+      - "metaDataDmpUss"
       - "uss_operator_exchange_id"
       - "gufi"
-      - "metaDataDmpUss"
       - "operator"
       - "human_interactions"
     properties:
@@ -503,9 +502,9 @@ definitions:
       USSs inform operators and how those operators react.  These data will
       be correlated with data captured via the USS Network.
     required:
+      - "metaDataDmpUss"
       - "dr_occurrence_id"
       - "gufi"
-      - "metaDataDmpUss"
       - "operator"
       - "time_uss_received"
       - "time_uss_sent"
@@ -624,13 +623,13 @@ definitions:
       may be an initial model that will be required operationally in terms of
       a USSs need to log interactions with other USSs.
     required:
+      - "metaDataDmpUss"
       - "measurement_id"
       - "event_id"
       - "exchanged_data_pk"
       - "exchanged_data_type"
       - "source_uss"
       - "target_uss"
-      - "metaDataDmpUss"
       - "time_request_initiation"
       - "time_request_completed"
       - "actual_http_response"

--- a/TCL4 Data Management/utm-tcl4-data-collection.yaml
+++ b/TCL4 Data Management/utm-tcl4-data-collection.yaml
@@ -24,7 +24,7 @@ definitions:
       - gufi
     properties:
       metaDataDmpUss:
-        $ref: 'https://raw.githubusercontent.com/nasa/utm-docs/add-meta-to-dmp-uss/TCL4%20Data%20Management/utm-tcl4-dmp-common.yaml#/definitions/metaDataDmpUss'
+        $ref: 'https://raw.githubusercontent.com/nasa/utm-docs/master/TCL4%20Data%20Management/utm-tcl4-dmp-common.yaml#/definitions/metaDataDmpUss'
       contact:
         description: >-
           Contact information of the reporter. Reference utm-commons for model.
@@ -159,7 +159,7 @@ definitions:
       - "active_gufis_under_management"
     properties:
       metaDataDmpUss:
-        $ref: 'https://raw.githubusercontent.com/nasa/utm-docs/add-meta-to-dmp-uss/TCL4%20Data%20Management/utm-tcl4-dmp-common.yaml#/definitions/metaDataDmpUss'
+        $ref: 'https://raw.githubusercontent.com/nasa/utm-docs/master/TCL4%20Data%20Management/utm-tcl4-dmp-common.yaml#/definitions/metaDataDmpUss'
       uss_loss_id:
         description: >-
           A UUID assigned by the reporting USS for this instance of LossOfUSS
@@ -227,7 +227,7 @@ definitions:
       - "gufi"
     properties:
       metaDataDmpUss:
-        $ref: 'https://raw.githubusercontent.com/nasa/utm-docs/add-meta-to-dmp-uss/TCL4%20Data%20Management/utm-tcl4-dmp-common.yaml#/definitions/metaDataDmpUss'
+        $ref: 'https://raw.githubusercontent.com/nasa/utm-docs/master/TCL4%20Data%20Management/utm-tcl4-dmp-common.yaml#/definitions/metaDataDmpUss'
       handoff_id:
         description: >-
           A UUID assigned by the reporting USS for this instance of
@@ -328,7 +328,7 @@ definitions:
       - "all_messages_within_spec"
     properties:
       metaDataDmpUss:
-        $ref: 'https://raw.githubusercontent.com/nasa/utm-docs/add-meta-to-dmp-uss/TCL4%20Data%20Management/utm-tcl4-dmp-common.yaml#/definitions/metaDataDmpUss'
+        $ref: 'https://raw.githubusercontent.com/nasa/utm-docs/master/TCL4%20Data%20Management/utm-tcl4-dmp-common.yaml#/definitions/metaDataDmpUss'
       negotiation_id:
         description: >-
           A UUID assigned by the reporting USS for this instance of
@@ -425,7 +425,7 @@ definitions:
       - "human_interactions"
     properties:
       metaDataDmpUss:
-        $ref: 'https://raw.githubusercontent.com/nasa/utm-docs/add-meta-to-dmp-uss/TCL4%20Data%20Management/utm-tcl4-dmp-common.yaml#/definitions/metaDataDmpUss'
+        $ref: 'https://raw.githubusercontent.com/nasa/utm-docs/master/TCL4%20Data%20Management/utm-tcl4-dmp-common.yaml#/definitions/metaDataDmpUss'
       uss_operator_exchange_id:
         description: >-
           A UUID assigned by the reporting USS for this instance of USS2OperatorExchange.
@@ -514,7 +514,7 @@ definitions:
 
     properties:
       metaDataDmpUss:
-        $ref: 'https://raw.githubusercontent.com/nasa/utm-docs/add-meta-to-dmp-uss/TCL4%20Data%20Management/utm-tcl4-dmp-common.yaml#/definitions/metaDataDmpUss'
+        $ref: 'https://raw.githubusercontent.com/nasa/utm-docs/master/TCL4%20Data%20Management/utm-tcl4-dmp-common.yaml#/definitions/metaDataDmpUss'
       dr_occurrence_id:
         description: >-
           A UUID assigned by the reporting USS for this instance of DynamicRestrictionOccurrence.
@@ -637,7 +637,7 @@ definitions:
       - "http_method"
     properties:
       metaDataDmpUss:
-        $ref: 'https://raw.githubusercontent.com/nasa/utm-docs/add-meta-to-dmp-uss/TCL4%20Data%20Management/utm-tcl4-dmp-common.yaml#/definitions/metaDataDmpUss'
+        $ref: 'https://raw.githubusercontent.com/nasa/utm-docs/master/TCL4%20Data%20Management/utm-tcl4-dmp-common.yaml#/definitions/metaDataDmpUss'
       measurement_id:
         description: >-
           A UUID assigned by the reporting USS for this instance of USSExchange.

--- a/TCL4 Data Management/utm-tcl4-data-collection.yaml
+++ b/TCL4 Data Management/utm-tcl4-data-collection.yaml
@@ -11,8 +11,8 @@ info:
 definitions:
   OffNominalReport:
     required:
+      - metaDataDmpUss
       - report_id
-      - uss_name
       - reason_for_report
       - scripted
       - role_responsibility
@@ -23,6 +23,8 @@ definitions:
       - reporter_narrative
       - gufi
     properties:
+      metaDataDmpUss:
+        $ref: 'https://raw.githubusercontent.com/nasa/utm-docs/add-meta-to-dmp-uss/TCL4%20Data%20Management/utm-tcl4-dmp-common.yaml#/definitions/metaDataDmpUss'
       contact:
         description: >-
           Contact information of the reporter. Reference utm-commons for model.
@@ -39,16 +41,6 @@ definitions:
         minLength: 36
         pattern: "^[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-4[0-9a-fA-F]{3}\\-[8-b][0-9a-fA-F]{3}\\-[0-9a-fA-F]{12}$"
         example: "00000000-0000-4444-8888-FEEDDEADBEEF"
-      uss_name:
-        description: >-
-          The name of the USS supporting the operation that went off nominal,
-          so this matches the uss Operation.uss_name field.
-
-          Also the name of the USS supporting this report.
-
-        type: "string"
-        format: "dns-name"
-        example: "uss.provider123.net"
       reason_for_report:
         description: >-
           The reason for this report. When activated operation enters nonconforming or rogue state, includes scripted off-nominal event, or unplanned RTL, loitering, landing occurs during operation, USS must prompt operator to file at least one report when the operation closes. Reason must be one of the following Enum value, [NONCONFORMING, ROGUE, NONCONFORMING2ROGUE, UNPLANNED_RTL, UNPLANNED_LOITER, UNPLANNED_LANDING, VOLUNTEER]. NONCONFORMING means the operation closed after entering nonconforming state. When multiple nonconformances occur use the first one as the reason. ROGUE means the operation closed after entering rogue state. NONCONFORMING2ROGUE means the operation entered nonconforming state then rogue state then closed. UNPLANNED_RTL means UA made unplanned return to the launch location (e.g., due to unexpected low battery status). UNPLANNED_LOITER means UA performed unplanned loitering or hovering (e.g., to regain C2 link). UNPLANNED_LANDING means UA made unplanned landing (e.g., due to unexpected low battery status). VOLUNTEER means this report is filed in addition to USS prompted mandatory one, OR filed without USS prompt (e.g., reporter requests the form to be made available).
@@ -160,28 +152,24 @@ definitions:
       in a single test, one submission is sufficient.
     required:
       - "uss_loss_id"
-      - "uss_name"
+      - "metaDataDmpUss"
       - "time_loss_detected"
       - "time_uss_completely_restored"
       - "method_loss_detected"
       - "active_gufis_under_management"
     properties:
+      metaDataDmpUss:
+        $ref: 'https://raw.githubusercontent.com/nasa/utm-docs/add-meta-to-dmp-uss/TCL4%20Data%20Management/utm-tcl4-dmp-common.yaml#/definitions/metaDataDmpUss'
+
       uss_loss_id:
         description: >-
-          A UUID assigned by the reporting USS for this instance of
-           USSNegotiation.
+          A UUID assigned by the reporting USS for this instance of LossOfUSS
         type: string
         format: uuid
         maxLength: 36
         minLength: 36
         pattern: "^[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-4[0-9a-fA-F]{3}\\-[8-b][0-9a-fA-F]{3}\\-[0-9a-fA-F]{12}$"
         example: "00000000-0000-4444-8888-FEEDDEADBEEF"
-      uss_name:
-        description: >-
-          The reporting USSs ID as known by USS Network/FIMS.
-        type: "string"
-        format: "dns-name"
-        example: "uss.provider123.net"
       time_loss_detected:
         description: >-
           Time the loss of USS was detected.  When did the managers of that USS
@@ -230,10 +218,9 @@ definitions:
       An instance of this model should be submitted by each USS involved in the
       handoff of management of an operation.  These data are not captured within
       the USSNetwork.  These data may inform future procedures and standards.
-
     required:
       - "handoff_id"
-      - "uss_name"
+      - "metaDataDmpUss"
       - "other_uss_id"
       - "operator"
       - "time_handoff_procedure_initiated"
@@ -250,12 +237,8 @@ definitions:
         minLength: 36
         pattern: "^[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-4[0-9a-fA-F]{3}\\-[8-b][0-9a-fA-F]{3}\\-[0-9a-fA-F]{12}$"
         example: "00000000-0000-4444-8888-FEEDDEADBEEF"
-      uss_name:
-        description: >-
-          The reporting USSs ID as known by USS Network/FIMS.
-        type: "string"
-        format: "dns-name"
-        example: "uss.provider123.net"
+      metaDataDmpUss:
+        $ref: 'https://raw.githubusercontent.com/nasa/utm-docs/add-meta-to-dmp-uss/TCL4%20Data%20Management/utm-tcl4-dmp-common.yaml#/definitions/metaDataDmpUss'
       other_uss_id:
         description: >-
           The other USSs ID (on the other side of the handoff) as known by
@@ -318,7 +301,6 @@ definitions:
         minLength: 1
         maxLength: 3000
 
-
   USSNegotiation:
     description: >-
       An instance of this model is required whenever a USS exchanges NegotiationMessages
@@ -337,14 +319,17 @@ definitions:
       there.
     required:
       - "negotiation_id"
-      - "uss_name"
+      - "metaDataDmpUss"
       - "reporter_gufi"
       - "other_gufi"
       - "message_ids"
       - "conflict_resolved"
       - "reporter_op_action"
       - "other_op_action"
+      - "all_messages_within_spec"
     properties:
+      metaDataDmpUss:
+        $ref: 'https://raw.githubusercontent.com/nasa/utm-docs/add-meta-to-dmp-uss/TCL4%20Data%20Management/utm-tcl4-dmp-common.yaml#/definitions/metaDataDmpUss'
       negotiation_id:
         description: >-
           A UUID assigned by the reporting USS for this instance of
@@ -355,13 +340,10 @@ definitions:
         minLength: 36
         pattern: "^[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-4[0-9a-fA-F]{3}\\-[8-b][0-9a-fA-F]{3}\\-[0-9a-fA-F]{12}$"
         example: "00000000-0000-4444-8888-FEEDDEADBEEF"
-
-      uss_name:
+      all_messages_within_spec:
+        type: boolean
         description: >-
-          The reporting USSs ID as known by USS Network/FIMS.
-        type: "string"
-        format: "dns-name"
-        example: "uss.provider123.net"
+          Add a boolean field that indicates the USS believes all messages were exchanged within the negotiations spec. Note that this value may be true while conflict_resolved may be false. We are trying to capture if the negotiation exchange did the right thing from the USS perspective.
       reporter_gufi:
         description: >-
           GUFI of the operation managed by reporting USS involved in this
@@ -378,7 +360,6 @@ definitions:
       other_gufi:
         description: >-
           GUFI of the other operation involved in this negotiation.
-
           If GUFI does not exist, use 00000000-0000-4444-8888-000000000000.
           If GUFI was generated after the negotiation, include that value.
         type: string
@@ -440,10 +421,12 @@ definitions:
     required:
       - "uss_operator_exchange_id"
       - "gufi"
-      - "uss_name"
+      - "metaDataDmpUss"
       - "operator"
       - "human_interactions"
     properties:
+      metaDataDmpUss:
+        $ref: 'https://raw.githubusercontent.com/nasa/utm-docs/add-meta-to-dmp-uss/TCL4%20Data%20Management/utm-tcl4-dmp-common.yaml#/definitions/metaDataDmpUss'
       uss_operator_exchange_id:
         description: >-
           A UUID assigned by the reporting USS for this instance of USS2OperatorExchange.
@@ -463,12 +446,6 @@ definitions:
         minLength: 36
         pattern: "^[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-4[0-9a-fA-F]{3}\\-[8-b][0-9a-fA-F]{3}\\-[0-9a-fA-F]{12}$"
         example: "00000000-0000-4444-8888-FEEDDEADBEEF"
-      uss_name:
-        description: >-
-          The reporting USSs ID as known by USS Network/FIMS.
-        type: "string"
-        format: "dns-name"
-        example: "uss.provider123.net"
       operator:
         type: "string"
         minLength: 4
@@ -528,7 +505,7 @@ definitions:
     required:
       - "dr_occurrence_id"
       - "gufi"
-      - "uss_name"
+      - "metaDataDmpUss"
       - "operator"
       - "time_uss_received"
       - "time_uss_sent"
@@ -537,6 +514,8 @@ definitions:
       - "message_to_operator"
 
     properties:
+      metaDataDmpUss:
+        $ref: 'https://raw.githubusercontent.com/nasa/utm-docs/add-meta-to-dmp-uss/TCL4%20Data%20Management/utm-tcl4-dmp-common.yaml#/definitions/metaDataDmpUss'
       dr_occurrence_id:
         description: >-
           A UUID assigned by the reporting USS for this instance of DynamicRestrictionOccurrence.
@@ -556,12 +535,6 @@ definitions:
         minLength: 36
         pattern: "^[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-4[0-9a-fA-F]{3}\\-[8-b][0-9a-fA-F]{3}\\-[0-9a-fA-F]{12}$"
         example: "00000000-0000-4444-8888-FEEDDEADBEEF"
-      uss_name:
-        description: >-
-          The reporting USSs ID as known by USS Network/FIMS.
-        type: "string"
-        format: "dns-name"
-        example: "uss.provider123.net"
       operator:
         type: "string"
         minLength: 4
@@ -657,13 +630,15 @@ definitions:
       - "exchanged_data_type"
       - "source_uss"
       - "target_uss"
-      - "uss_name"
+      - "metaDataDmpUss"
       - "time_request_initiation"
       - "time_request_completed"
       - "actual_http_response"
       - "endpoint"
       - "http_method"
     properties:
+      metaDataDmpUss:
+        $ref: 'https://raw.githubusercontent.com/nasa/utm-docs/add-meta-to-dmp-uss/TCL4%20Data%20Management/utm-tcl4-dmp-common.yaml#/definitions/metaDataDmpUss'
       measurement_id:
         description: >-
           A UUID assigned by the reporting USS for this instance of USSExchange.
@@ -716,18 +691,6 @@ definitions:
         type: "string"
         format: "dns-name"
         example: "utm.cool-uss-team.com"
-      uss_name:
-        description: >-
-          The reporting USSs ID as known by USS Network/FIMS.
-
-          Note this will be a duplicate of either target_uss or source_uss.
-
-          Note that the addition of this field means we could remove
-          reporting_uss_role, but will leave for now, changing to an
-          optional field to minimize affect on current implementations.
-        type: "string"
-        format: "dns-name"
-        example: "uss.provider123.net"
       reporting_uss_role:
         description: >-
           An enum indicating if the USS providing these data was the one that initiated the request (SOURCE_USS) or the USS that received the request (TARGET_USS).
@@ -803,29 +766,6 @@ definitions:
         maximum: 599
         exclusiveMaximum: false
         example: 204
-      jws:
-        description: >-
-          The JWS that was included in the data exchange. If a PUT/POST then
-          the SOURCE_USS would have generated and sent to TARGET_USS.  If a GET
-          then the TARGET_USS would have generated and sent to the SOURCE_USS.
-          In either case, both the SOURCE_USS and the TARGET_USS should include
-          the resulting JWS here.
-
-          This field is now marked as optional since we will not always be
-          exchanging JWS in every simulation.  If JWS is required for the sim
-          then this field should also be considered required.
-
-          We currently have no max size for this field, but eventually we should.
-        type: "string"
-        format: "jws (base64url)"
-      jws_public_key:
-        description: >-
-          If available, include the public key for decoding the jws. Recommended
-          whenever jws field is non-null.
-
-          We currently have no max size for this field, but eventually we should.
-        type: "string"
-        format: "base64"
       comments:
         description: >-
           Any additional comments that could aid in analysis involving these data.

--- a/TCL4 Data Management/utm-tcl4-dmp-common.yaml
+++ b/TCL4 Data Management/utm-tcl4-dmp-common.yaml
@@ -37,7 +37,7 @@ info:
     UNILATERAL TERMINATION OF THIS AGREEMENT.
 
 definitions:
-  metadataTestSite:
+  metaDataTestSite:
     type: object
     required:
       - scenario
@@ -94,6 +94,54 @@ definitions:
         $ref: '#/definitions/metaData'
       timestamp:
         $ref: '#/definitions/timestamp'
+
+  metaDataDmpUss:
+    type: object
+    required:
+      - data_collection
+      - call_sign
+      - test_run
+      - uss_name
+    properties:
+      data_collection:
+        description: >-
+          If true these data are intended for Data Collection. Essentially
+          stating if particular data should be ignored during analysis. This
+          may be modified after submission in the case that there was an issue
+          during execution of the test/experiment that would invalidate the
+          data that were collected.
+        type: boolean
+      call_sign:
+        type: string
+        minLength: 1
+        maxLength: 100
+        description: >-
+          Expected values: a call sign, test card role, or flight ID that links
+          this operation to a particular test card flight. As an example, in our
+          TCL2 demo, "GCS3" could have been used here. For multiple flights
+          emanating from one location on a test card, this data element could
+          include further information to link the operation to the test card
+          flight, such as GCS1A.
+
+          Every operation requires a call_sign that is pre-determined in the
+          full test card description.
+      uss_name:
+        type: string
+        description: >-
+          This is a unique string that identifies the USS that is supporting
+          this operation.  It is the same identifier used in the basic
+          authentication mechanism required to obtain a token from FIMS
+          (Flight Information Management System).  It is also the subject claim
+          that identifies the principal that is the subject of the JWT.
+      test_run:
+        description: >-
+          An identifier for a specific run of a test_card.  In many cases, a
+          test_card may be only run once.  However, it is possible that a
+          test_card is run multiple times.
+        minLength: 1
+        maxLength: 100
+        type: string
+
   metaData:
     type: object
     required:


### PR DESCRIPTION
adding metadata to the dmp uss models.  After discussion with @lmadhavrao  and examining the other meta data models available - we decided this was the cleanest approach.  Also added a field from issue: https://github.com/nasa/utm-docs/issues/16
