### PR TITLE
Changed property name so matches what is in the "required" list.

### DIFF
--- a/TCL4 Data Management/utm-tcl4-dmp-fet-latency.yaml
+++ b/TCL4 Data Management/utm-tcl4-dmp-fet-latency.yaml
@@ -88,7 +88,7 @@ definitions:
     properties:
       metaData:
         $ref: 'https://raw.githubusercontent.com/nasa/utm-docs/develop/TCL4%20Data%20Management/utm-tcl4-dmp-common.yaml#/definitions/metaData'
-      sensorLatencyTupleArray:
+      sensorLatencyTuple:
         description: >-
           An array of sensor latency samples.  Note that the types of samples can be
           mixed in this array.  


### PR DESCRIPTION
This is also consistent with the 1-to-1 mapping from DMP data elements to where they are collected within the data models. We sent out this mapping test sites in the DMP Rev 3 last week.