### PR TITLE
Description updates

### DIFF
--- a/TCL4 Data Management/utm-tcl4-data-collection.yaml
+++ b/TCL4 Data Management/utm-tcl4-data-collection.yaml
@@ -19,6 +19,11 @@ paths:
             when there are no paths, but domains do not contain paths.
 definitions:
   OffNominalReport:
+    description: >-
+      ---- IMPORTANT NOTE ----
+      Please be advised: 'time_occurence' is to be included with ALL submissions
+      of this data model (despite not being listed as a "required" field).
+      -----------------------
     required:
       - metaDataDmpUss
       - report_id
@@ -137,8 +142,9 @@ definitions:
           - OTHER
       time_occurrence:
         description: >-
-            date and time of off-nominal event in UTC, ONLY to be filled when
-            value for the variable "reason_for_report" is "VOLUNTEER"
+            date and time of off-nominal event in UTC.
+
+            This field is REQUIRED for all Off-Nominal Reports
         type: string
         format: date-time
         minLength: 24

--- a/TCL4 Data Management/utm-tcl4-data-collection.yaml
+++ b/TCL4 Data Management/utm-tcl4-data-collection.yaml
@@ -718,7 +718,7 @@ definitions:
         type: "string"
         format: "dns-name"
         example: "uss.provider123.net"
-        $ref: 'https://raw.githubusercontent.com/nasa/utm-docs/develop/TCL4%20Data%20Management/utm-tcl4-dmp-common.yaml#/definitions/metaDataDmpUss'
+        $ref: 'https://raw.githubusercontent.com/nasa/utm-docs/develop/TCL4%20Data%20Management/utm-tcl4-dmp-common.yaml#/definitions/MetaDataDmpUssId'
       target_uss:
         description: >-
           This is the uss_name of the target_uss.
@@ -727,7 +727,7 @@ definitions:
         type: "string"
         format: "dns-name"
         example: "utm.cool-uss-team.com"
-        $ref: 'https://raw.githubusercontent.com/nasa/utm-docs/develop/TCL4%20Data%20Management/utm-tcl4-dmp-common.yaml#/definitions/metaDataDmpUss'
+        $ref: 'https://raw.githubusercontent.com/nasa/utm-docs/develop/TCL4%20Data%20Management/utm-tcl4-dmp-common.yaml#/definitions/MetaDataDmpUssId'
       reporting_uss_role:
         description: >-
           An enum indicating if the USS providing these data was the one that initiated the request (SOURCE_USS) or the USS that received the request (TARGET_USS).

--- a/TCL4 Data Management/utm-tcl4-data-collection.yaml
+++ b/TCL4 Data Management/utm-tcl4-data-collection.yaml
@@ -274,6 +274,8 @@ definitions:
         pattern: "^[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-4[0-9a-fA-F]{3}\\-[8-b][0-9a-fA-F]{3}\\-[0-9a-fA-F]{12}$"
         example: "00000000-0000-4444-8888-FEEDDEADBEEF"
       operator:
+        description: >-
+          A registered entity who conducts/manages a particular flight activity.
         type: "string"
         minLength: 4
         maxLength: 100
@@ -460,6 +462,8 @@ definitions:
         pattern: "^[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-4[0-9a-fA-F]{3}\\-[8-b][0-9a-fA-F]{3}\\-[0-9a-fA-F]{12}$"
         example: "00000000-0000-4444-8888-FEEDDEADBEEF"
       operator:
+        description: >-
+          A registered entity who conducts/manages a particular flight activity.
         type: "string"
         minLength: 4
         maxLength: 100
@@ -551,6 +555,8 @@ definitions:
         pattern: "^[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-4[0-9a-fA-F]{3}\\-[8-b][0-9a-fA-F]{3}\\-[0-9a-fA-F]{12}$"
         example: "00000000-0000-4444-8888-FEEDDEADBEEF"
       operator:
+        description: >-
+          A registered entity who conducts/manages a particular flight activity.
         type: "string"
         minLength: 4
         maxLength: 100
@@ -699,13 +705,23 @@ definitions:
           - OTHER_SEE_COMMENT
         example: "POSITION"
       source_uss:
+        description: >-
+          This is the uss_name of the source_uss.
+
+          See reference for definition of uss_name.
         type: "string"
         format: "dns-name"
         example: "uss.provider123.net"
+        $ref: 'https://raw.githubusercontent.com/nasa/utm-docs/develop/TCL4%20Data%20Management/utm-tcl4-dmp-common.yaml#/definitions/metaDataDmpUss'
       target_uss:
+        description: >-
+          This is the uss_name of the target_uss.
+
+          See reference for definition of uss_name.
         type: "string"
         format: "dns-name"
         example: "utm.cool-uss-team.com"
+        $ref: 'https://raw.githubusercontent.com/nasa/utm-docs/develop/TCL4%20Data%20Management/utm-tcl4-dmp-common.yaml#/definitions/metaDataDmpUss'
       reporting_uss_role:
         description: >-
           An enum indicating if the USS providing these data was the one that initiated the request (SOURCE_USS) or the USS that received the request (TARGET_USS).

--- a/TCL4 Data Management/utm-tcl4-data-collection.yaml
+++ b/TCL4 Data Management/utm-tcl4-data-collection.yaml
@@ -57,7 +57,20 @@ definitions:
         example: "00000000-0000-4444-8888-FEEDDEADBEEF"
       reason_for_report:
         description: >-
-          The reason for this report. When activated operation enters nonconforming or rogue state, includes scripted off-nominal event, or unplanned RTL, loitering, landing occurs during operation, USS must prompt operator to file at least one report when the operation closes. Reason must be one of the following Enum value, [NONCONFORMING, ROGUE, NONCONFORMING2ROGUE, UNPLANNED_RTL, UNPLANNED_LOITER, UNPLANNED_LANDING, VOLUNTEER]. NONCONFORMING means the operation closed after entering nonconforming state. When multiple nonconformances occur use the first one as the reason. ROGUE means the operation closed after entering rogue state. NONCONFORMING2ROGUE means the operation entered nonconforming state then rogue state then closed. UNPLANNED_RTL means UA made unplanned return to the launch location (e.g., due to unexpected low battery status). UNPLANNED_LOITER means UA performed unplanned loitering or hovering (e.g., to regain C2 link). UNPLANNED_LANDING means UA made unplanned landing (e.g., due to unexpected low battery status). VOLUNTEER means this report is filed in addition to USS prompted mandatory one, OR filed without USS prompt (e.g., reporter requests the form to be made available).
+          The reason for this report. When an activated operation enters nonconforming
+          or rogue state, includes scripted off-nominal event, or unplanned RTL,
+          loitering, landing occurs during operation, USS must prompt operator to
+          file at least one report when the operation closes.
+
+          Reason must be one of the following Enum values:
+          [NONCONFORMING, ROGUE, NONCONFORMING2ROGUE, UNPLANNED_RTL, UNPLANNED_LOITER, UNPLANNED_LANDING, VOLUNTEER].
+          NONCONFORMING means the operation closed after entering nonconforming state. When multiple nonconformances occur use the first one as the reason.
+          ROGUE means the operation closed after entering rogue state.
+          NONCONFORMING2ROGUE means the operation entered nonconforming state then rogue state then closed.
+          UNPLANNED_RTL means UA made unplanned return to the launch location (e.g., due to unexpected low battery status).
+          UNPLANNED_LOITER means UA performed unplanned loitering or hovering (e.g., to regain C2 link).
+          UNPLANNED_LANDING means UA made unplanned landing (e.g., due to unexpected low battery status).
+          VOLUNTEER means this report is filed in addition to USS prompted mandatory one, OR filed without USS prompt (e.g., reporter requests the form to be made available).
         type: string
         enum:
           - NONCONFORMING
@@ -133,7 +146,9 @@ definitions:
         maxLength: 15000
       flight_rule:
         description: >-
-          FAA rule for the operation, ONLY to be filled when value for the variable "reason_for_report" is "VOLUNTEER". Use the following Enum values. [PART_107, PART_107X, PART_101E, OTHER]
+          FAA rule for the operation, ONLY to be filled when value for the variable
+          "reason_for_report" is "VOLUNTEER".
+          Use the following Enum values: [PART_107, PART_107X, PART_101E, OTHER]
         type: string
         enum:
           - PART_107
@@ -785,7 +800,8 @@ definitions:
         example: "PUT"
       expected_http_response:
         description: >-
-          The expected HTTP response code.  This is required ONLY if the reporting_uss_role is SOURCE_USS.
+          The expected HTTP response code.
+          This is required ONLY if the reporting_uss_role is SOURCE_USS.
         type: "integer"
         format: "int32"
         minimum: 100
@@ -795,7 +811,8 @@ definitions:
         example: 204
       actual_http_response:
         description: >-
-          The actual HTTP response code sent by the TARGET_USS to the SOURCE_USS. Must be reported by USSs in either role.
+          The actual HTTP response code sent by the TARGET_USS to the SOURCE_USS.
+          Must be reported by USSs in either role.
         type: "integer"
         format: "int32"
         minimum: 100

--- a/TCL4 Data Management/utm-tcl4-dmp-aircraft-flightplan.yaml
+++ b/TCL4 Data Management/utm-tcl4-dmp-aircraft-flightplan.yaml
@@ -67,10 +67,11 @@ definitions:
           - FLY_BY
           - FLY_OVER
       position:
-        description: 2D position of the waypoint.
+        description: 2D position of the waypoint. (Lat/Lon)
         $ref: 'https://raw.githubusercontent.com/nasa/utm-apis/v4-draft/utm-domains/utm-domain-geojson.yaml#/definitions/Point'
       altitude:
-        description: targeted altitude of the waypoint.
+        description: >-
+          Targeted altitude of the waypoint expressed in WGS84 reference frame (ft)
         $ref: 'https://raw.githubusercontent.com/nasa/utm-apis/v4-draft/utm-domains/utm-domain-commons.yaml#/definitions/Altitude'
       timestamp:
         description: >-
@@ -103,7 +104,7 @@ definitions:
         example: 32
       hover_time:
         description: >-
-          number of seconds the vehicle plans to hover or loiter at this waypoint.
+          Number of seconds the vehicle plans to hover or loiter at this waypoint.
         type: integer
         format: int32
         minimum: 0

--- a/TCL4 Data Management/utm-tcl4-dmp-cns.yaml
+++ b/TCL4 Data Management/utm-tcl4-dmp-cns.yaml
@@ -74,22 +74,22 @@ definitions:
         minimum: 0
       maximumAircraftToOperatorRoundTripLatencyTolerableForOperation_ms:
         description: >-
-          "Report the maximum tolerable Round-trip latency from source to
-          destination to execute the operation, in millisecond (ms)"
+          "Report the maximum tolerable Round-trip latency from source (aircraft)
+          to destination (operator) to execute the operation, in millisecond (ms)"
         type: integer
         format: int32
         minimum: 0
       maximumOperatorToAircraftRoundTripLatencyTolerableForOperation_ms:
         description: >-
-          "Report the maximum tolerable Round-trip latency from source to
-          destination to execute the operation, in millisecond (ms)"
+          "Report the maximum tolerable Round-trip latency from source (operator)
+          to destination (aircraft) to execute the operation, in millisecond (ms)"
         type: number
         format: int32
         minimum: 0
 
   UasTruthPosition:
     description: >-
-      As reported by truth position system 
+      As reported by truth position system
     type: object
     required:
       - "metaData"
@@ -101,28 +101,31 @@ definitions:
       metaData:
         $ref: 'https://raw.githubusercontent.com/nasa/utm-docs/develop/TCL4%20Data%20Management/utm-tcl4-dmp-common.yaml#/definitions/metaData'
       xCoordinate_ft:
-        description: "X-Coordinate truth position of UA (ECEF: Earth Centered Earth\
-          \ Fixed, inch-level resolution);\nas reported by the Ground Truth System\
-          \ (Truth Reference System, e.g. optical, radar, LiDAR, nav. beacon, etc).\n\
-          Can be reported by the UAS but has to be independent of UAS's primary navigation\
-          \ system,\nuse of separate RTK system is allowed (UTC time stamped).\nReport\
-          \ at least 2 decimal places of precision. (ft)"
+        description: >-
+          X-Coordinate truth position of UA (ECEF: Earth Centered Earth
+          Fixed, inch-level resolution); as reported by the Ground Truth System
+          (Truth Reference System, e.g. optical, radar, LiDAR, nav. beacon, etc).
+          Can be reported by the UAS but has to be independent of UAS's primary navigation
+          system, use of separate RTK system is allowed (UTC time stamped). Report
+          at least 2 decimal places of precision. (ft)
         $ref: "#/definitions/UasTruthEcefCoordinate_ft"
       yCoordinate_ft:
-        description: "Y-Coordinate truth position of UA (ECEF: Earth Centered Earth\
-          \ Fixed, inch-level resolution);\nas reported by the Ground Truth System\
-          \ (Truth Reference System, e.g. optical, radar, LiDAR, nav. beacon, etc).\n\
-          Can be reported by the UAS but has to be independent of UAS's primary navigation\
-          \ system,\nuse of separate RTK system is allowed (UTC time stamped).\nReport\
-          \ at least 2 decimal places of precision. (ft)"
+        description: >-
+          Y-Coordinate truth position of UA (ECEF: Earth Centered Earth
+          Fixed, inch-level resolution); as reported by the Ground Truth System
+          (Truth Reference System, e.g. optical, radar, LiDAR, nav. beacon, etc).
+          Can be reported by the UAS but has to be independent of UAS's primary navigation
+          system, use of separate RTK system is allowed (UTC time stamped). Report
+          at least 2 decimal places of precision. (ft)
         $ref: "#/definitions/UasTruthEcefCoordinate_ft"
       zCoordinate_ft:
-        description: "Z-Coordinate truth position of UA (ECEF: Earth Centered Earth\
-          \ Fixed, inch-level resolution);\nas reported by the Ground Truth System\
-          \ (Truth Reference System, e.g. optical, radar, LiDAR, nav. beacon, etc).\n\
-          Can be reported by the UAS but has to be independent of UAS's primary navigation\
-          \ system,\nuse of separate RTK system is allowed (UTC time stamped).\nReport\
-          \ at least 2 decimal places of precision. (ft)"
+        description: >-
+          Z-Coordinate truth position of UA (ECEF: Earth Centered Earth
+          Fixed, inch-level resolution); as reported by the Ground Truth System
+          (Truth Reference System, e.g. optical, radar, LiDAR, nav. beacon, etc).
+          Can be reported by the UAS but has to be independent of UAS's primary navigation
+          system, use of separate RTK system is allowed (UTC time stamped). Report
+          at least 2 decimal places of precision. (ft)
         $ref: "#/definitions/UasTruthEcefCoordinate_ft"
       timestamp:
         $ref: 'https://raw.githubusercontent.com/nasa/utm-docs/develop/TCL4%20Data%20Management/utm-tcl4-dmp-common.yaml#/definitions/timestamp'

--- a/TCL4 Data Management/utm-tcl4-dmp-common.yaml
+++ b/TCL4 Data Management/utm-tcl4-dmp-common.yaml
@@ -109,7 +109,7 @@ definitions:
         type: integer
       timestamp:
         $ref: '#/definitions/timestamp'
-        
+
   metaDataTs:
     type: object
     required:
@@ -141,7 +141,7 @@ definitions:
         maxLength: 1000
       id:
         $ref: '#/definitions/UUID'
-    
+
   metaDataDmpUss:
     type: object
     required:
@@ -331,7 +331,7 @@ definitions:
         $ref: '#/definitions/UUID'
       timestamp:
         $ref: '#/definitions/timestamp'
-        
+
   MetaDataTsArray:
     description: >-
       Data model used to delete data by specifying a meta data data model and an array of timestamps.
@@ -349,7 +349,7 @@ definitions:
           $ref: '#/definitions/timestamp'
         minItems: 1
         maxItems: 10000
-        
+
   timestamp:
     description: >-
       Timestamps MUST follow the guidance set forth in RFC3339.
@@ -414,7 +414,7 @@ definitions:
       alt:
        $ref: '#/definitions/altitude'
 
-  CallSign: 
+  CallSign:
     type: string
     minLength: 1
     maxLength: 100
@@ -422,7 +422,7 @@ definitions:
       A UTM TCL4 globally unique identifier that is associated with a vehicle/operation
       Every operation requires a call_sign that is pre-determined in the
       full test card description.
-       
+
   latitude:
     description: >-
       The numeric value of the latitude. Note that min and max values are added as a sanity check.
@@ -492,8 +492,10 @@ definitions:
     format: int32
     minimum: 0
     example: 5
-    
+
   SensorList:
+    description: >-
+      Refer to DMP for individual definitions and units of each of these sensors.
     type: string
     enum:
       - LAT

--- a/TCL4 Data Management/utm-tcl4-dmp-con.yaml
+++ b/TCL4 Data Management/utm-tcl4-dmp-con.yaml
@@ -158,7 +158,7 @@ definitions:
          description: >-
            Report configured distress broadcast rate. (Hz)
 
-           Report a broadcrast rate of 0 Hz if the vehilce is not equipped
+           Report a broadcrast rate of 0 Hz if the vehicle is not equipped
            with distressV2V capability.
          type: number
          format: float

--- a/TCL4 Data Management/utm-tcl4-dmp-con.yaml
+++ b/TCL4 Data Management/utm-tcl4-dmp-con.yaml
@@ -72,6 +72,11 @@ definitions:
           Report at least seven decimal degrees. (deg).
         $ref: '#/definitions/LatLonAltArray'
       wxOperatingPoints:
+        description: >-
+          Lat/Lon/Alt list of points where weather data is collected.
+
+          For Lat/Lon, report at least seven decimal degrees. (deg)
+          For Alt, express in WGS84 standard. (ft).
         $ref: '#/definitions/LatLonAltArray'
       cellCoverageAreas:
         description: >-
@@ -108,16 +113,46 @@ definitions:
       metaData:
         $ref: 'https://raw.githubusercontent.com/nasa/utm-docs/develop/TCL4%20Data%20Management/utm-tcl4-dmp-common.yaml#/definitions/metaData'
       plannedBvlosLandingPoints:
+        description: >-
+          Lat/Lon/Alt list of planned BVLOS landing point(s).
+
+          For Lat/Lon, report at least seven decimal degrees. (deg)
+          For Alt, express in WGS84 standard. (ft)
         $ref: '#/definitions/LatLonAltArray'
       plannedVlosLandingPoints:
+        description: >-
+          Lat/Lon/Alt list of planned VLOS landing point(s).
+
+          For Lat/Lon, report at least seven decimal degrees. (deg)
+          For Alt, express in WGS84 standard. (ft)
+
         $ref: '#/definitions/LatLonAltArray'
       plannedRooftopLandingPoints:
+        description: >-
+          Lat/Lon/Alt list of planned rooftop landing point(s).
+
+          For Lat/Lon, report at least seven decimal degrees. (deg)
+          For Alt, express in WGS84 standard. (ft)
         $ref: '#/definitions/LatLonAltArray'
       safeLandingLocations:
+        description: >-
+          Lat/Lon/Alt list of dedicated pre-defined safe landing locations.
+
+          For Lat/Lon, report at least seven decimal degrees. (deg)
+          For Alt, express in WGS84 standard. (ft)
         $ref: '#/definitions/LatLonAltArray'
       safeLandingLocationPolygonPoints:
+        description: >-
+          Lat/Lon/Alt list of the vertices of the polygons around 'safeLandingLocations'.
+
+          For Lat/Lon, report at least seven decimal degrees. (deg)
+          For Alt, express in WGS84 standard. (ft)
         $ref: '#/definitions/LatLonAltArray'
       rpicLocations:
+        descrpition: >-
+          Lat/Lon/Alt list of RPIC locations.
+          For Lat/Lon, report at least seven decimal degrees. (deg)
+          For Alt, express in WGS84 standard. (ft)
         $ref: '#/definitions/LatLonAltArray'
       distressBroadcastRate:
          description: >-
@@ -148,10 +183,10 @@ definitions:
         $ref: '#/definitions/LatLonAlt'
       landingOffset:
         description: >-
-          lateral distance between planned landing point and
+          Lateral distance between planned landing point and
           actual landing point using vehicle independent GNSS or non-GNSS systems.
           Could use tape to measure the center-to-center distance between the points
-          on the ground.
+          on the ground. (ft)
         type: number
       isBVLOS:
         description: >-
@@ -173,7 +208,8 @@ definitions:
   ConWxOperatingPointData:
     description: >-
            Temperature, air pressure (in Hg), windspeed (ft/sec), wind direction,
-           location, and timestamp associated with the measurement from a vehicle
+           location, and timestamp associated with the measurement from a sensor
+           on a UA.
     type: object
     required:
       - "metaData"
@@ -216,7 +252,8 @@ definitions:
   ConWxOperatingPointDataStation:
     description: >-
            Temperature, air pressure (in Hg), windspeed (ft/sec), wind direction,
-           location, and timestamp associated with the measurement from weather station
+           location, and timestamp associated with the measurement from a
+           weather station on the ground.
     type: object
     required:
       - "metaDataTestSite"
@@ -264,7 +301,7 @@ definitions:
         type: string
         minLength: 1
         maxLength: 1000
-        
+
   CellServiceAvailability:
     description: >-
       Real-time availability of cellular service onboard the ownship during the
@@ -281,6 +318,11 @@ definitions:
       metaData:
         $ref: 'https://raw.githubusercontent.com/nasa/utm-docs/develop/TCL4%20Data%20Management/utm-tcl4-dmp-common.yaml#/definitions/metaData'
       cellServiceAvailabilityValue:
+        description: >-
+          Real-time availability of cellular service onboard the ownship during
+          the flight, specify status as enum.
+
+          Report at least at 1Hz sampling frequency or higher.
         type: string
         enum:
           - CONNECTED
@@ -389,6 +431,9 @@ definitions:
 
       If used to describe a Polygon, the first point and the last point must
       be equal.
+
+      Latitude, Longitude, Altitude should have precision of 7 or more digits.
+      Report altitude in WGS84. (ft)
     type: array
     items:
       $ref: '#/definitions/LatLonAlt'
@@ -400,6 +445,8 @@ definitions:
 
       If used to describe a Polygon, the first point and the last point must
       be equal.
+
+      Latitude and Longitude should have precision of 7 or more digits.
     type: array
     items:
       $ref: '#/definitions/LatLon'
@@ -439,4 +486,3 @@ definitions:
         maxItems: 300
         items:
           $ref: 'https://raw.githubusercontent.com/nasa/utm-apis/master/utm-domains/utm-domain-geojson.yaml#/definitions/Polygon'
-

--- a/TCL4 Data Management/utm-tcl4-dmp-con.yaml
+++ b/TCL4 Data Management/utm-tcl4-dmp-con.yaml
@@ -125,7 +125,6 @@ definitions:
 
           For Lat/Lon, report at least seven decimal degrees. (deg)
           For Alt, express in WGS84 standard. (ft)
-
         $ref: '#/definitions/LatLonAltArray'
       plannedRooftopLandingPoints:
         description: >-
@@ -151,12 +150,16 @@ definitions:
       rpicLocations:
         descrpition: >-
           Lat/Lon/Alt list of RPIC locations.
+
           For Lat/Lon, report at least seven decimal degrees. (deg)
           For Alt, express in WGS84 standard. (ft)
         $ref: '#/definitions/LatLonAltArray'
       distressBroadcastRate:
          description: >-
            Report configured distress broadcast rate. (Hz)
+
+           Report a broadcrast rate of 0 Hz if the vehilce is not equipped
+           with distressV2V capability.
          type: number
          format: float
 
@@ -207,9 +210,9 @@ definitions:
 
   ConWxOperatingPointData:
     description: >-
-           Temperature, air pressure (in Hg), windspeed (ft/sec), wind direction,
-           location, and timestamp associated with the measurement from a sensor
-           on a UA.
+      Temperature, air pressure (in Hg), windspeed (ft/sec), wind direction,
+      location, and timestamp associated with the measurement from a sensor
+      on a UA.
     type: object
     required:
       - "metaData"
@@ -251,9 +254,9 @@ definitions:
 
   ConWxOperatingPointDataStation:
     description: >-
-           Temperature, air pressure (in Hg), windspeed (ft/sec), wind direction,
-           location, and timestamp associated with the measurement from a
-           weather station on the ground.
+      Temperature, air pressure (in Hg), windspeed (ft/sec), wind direction,
+      location, and timestamp associated with the measurement from a
+      weather station on the ground.
     type: object
     required:
       - "metaDataTestSite"
@@ -432,8 +435,8 @@ definitions:
       If used to describe a Polygon, the first point and the last point must
       be equal.
 
-      Latitude, Longitude, Altitude should have precision of 7 or more digits.
-      Report altitude in WGS84. (ft)
+      Lat/Lon, should have precision of 7 or more digits.
+      For Alt, express in WGS84 standard. (ft)
     type: array
     items:
       $ref: '#/definitions/LatLonAlt'
@@ -446,7 +449,7 @@ definitions:
       If used to describe a Polygon, the first point and the last point must
       be equal.
 
-      Latitude and Longitude should have precision of 7 or more digits.
+      Lat/Lon, should have precision of 7 or more digits.
     type: array
     items:
       $ref: '#/definitions/LatLon'

--- a/TCL4 Data Management/utm-tcl4-dmp-daa-geofence.yaml
+++ b/TCL4 Data Management/utm-tcl4-dmp-daa-geofence.yaml
@@ -53,7 +53,7 @@ definitions:
           1. This id should remain constant across multiple geofence samples for a
           dynamic geofence associated with the same metaData model.
 
-          2. Samples for a single metaData model differentiated and ordered by 
+          2. Samples for a single metaData model differentiated and ordered by
           timestamps.
         type: string
         format: uuid
@@ -108,7 +108,7 @@ definitions:
         example: "POLYGON"
       min_altitude:
         description: >-
-          Altitude floor of the geofence.
+          Altitude floor of the geofence in WGS84. (ft)
         $ref: 'https://raw.githubusercontent.com/nasa/utm-apis/v4-draft/utm-domains/utm-domain-commons.yaml#/definitions/Altitude'
         example:
           min_altitude:
@@ -117,7 +117,7 @@ definitions:
             units_of_measure: "FT"
       max_altitude:
         description: >-
-          Altitude ceiling of the geofence.
+          Altitude ceiling of the geofence in WGS84. (ft)
         $ref: 'https://raw.githubusercontent.com/nasa/utm-apis/v4-draft/utm-domains/utm-domain-commons.yaml#/definitions/Altitude'
         example:
           max_altitude:
@@ -126,7 +126,7 @@ definitions:
             units_of_measure: "FT"
       circular_geofence_center:
         description: >-
-          Circular origin point of the geofence, if circular.
+          Circular origin point of the geofence, if circular. (Lat/Lon)
         $ref: 'https://raw.githubusercontent.com/nasa/utm-apis/v4-draft/utm-domains/utm-domain-geojson.yaml#/definitions/Point'
       circular_geofence_radius:
         description: >-
@@ -137,5 +137,5 @@ definitions:
         example: 200.0
       polygonal_geofence_boundary:
         description: >-
-          Geofence boundary if a polygon.
+          Geofence boundary if a polygon. (Lat/Lon)
         $ref: 'https://raw.githubusercontent.com/nasa/utm-apis/v4-draft/utm-domains/utm-domain-geojson.yaml#/definitions/Polygon'

--- a/TCL4 Data Management/utm-tcl4-dmp-daa.yaml
+++ b/TCL4 Data Management/utm-tcl4-dmp-daa.yaml
@@ -115,7 +115,8 @@ definitions:
         maxLength: 500
       probabilityIntruderDetectionPrct:
         description: >-
-          The likelihood of detection of a intruder aircraft within the surveillance coverage of the sensor. Express in percentage, between 0 and 100.
+          The likelihood of detection of a intruder aircraft within the surveillance coverage of the sensor.
+          Express in percentage, between 0 and 100.
         $ref: "#/definitions/percent"
       targetTrackCapacity:
         description: >-
@@ -127,11 +128,13 @@ definitions:
         $ref: "#/definitions/hertz"
       sensorMaxHorzRangeData:
         description: >-
-          Expected maximum relative horizontal range as detected by a sensor in the north east down reference frame of the ownship aircraft. Provided as a vector of Radar Cross Section and range: [RCS_min (ft^2), RCS_max (ft^2), range (ft)]
+          Expected maximum relative horizontal range as detected by a sensor in
+          the north east down reference frame of the ownship aircraft. (ft)
         $ref: "#/definitions/feet"
       sensorMinHorzRangeData:
         description: >-
-          Expected minimum relative horizontal range as detected by a sensor in the north east down reference frame of the ownship aircraft. Provided as a vector of Radar Cross Section and range: [RCS_min (ft^2), RCS_max (ft^2), range (ft)]
+          Expected minimum relative horizontal range as detected by a sensor in
+          the north east down reference frame of the ownship aircraft. (ft)
         $ref: "#/definitions/feet"
       maxHorzRcsOfSensor:
         description: >-
@@ -154,12 +157,12 @@ definitions:
       sensorMaxVertRange:
         description: >-
           Expected maximum relative vertical range as detected by a sensor in
-          the north east down reference frame of the ownship aircraft.
+          the north east down reference frame of the ownship aircraft. (ft)
         $ref: "#/definitions/feet"
       sensorMinVertRange:
         description: >-
           Expected minimum relative vertical range as detected by a sensor in
-          the north east down reference frame of the ownship aircraft.
+          the north east down reference frame of the ownship aircraft. (ft)
         $ref: "#/definitions/feet"
       maxVertRcsOfSensor:
         description: >-
@@ -189,7 +192,10 @@ definitions:
         $ref: "#/definitions/degrees"
       daaSensorAzimuthAccuracy:
         description: >-
-          Manufacturer provided specification of azimuth accuracy of the sensor: uncertainty of the azimuth measurement for the sensor. Accuracy = how close a measured value is to the actual (true) value (e.g. for accuracy +/- 5, write "5"). (deg)
+          Manufacturer provided specification of azimuth accuracy of the sensor:
+            uncertainty of the azimuth measurement for the sensor.
+            Accuracy = how close a measured value is to the actual (true) value
+            (e.g. for accuracy +/- 5, write "5"). (deg)
         $ref: "#/definitions/degrees"
       elevationSensorMax:
         description: >-
@@ -201,7 +207,10 @@ definitions:
         $ref: "#/definitions/degrees"
       daaSensorElevationAccuracy:
         description: >-
-          Manufacturer provided specification of elevation accuracy of the sensor: This is the accuracy uncertainty of the elevation measurement for the sensor. Accuracy = how close a measured value is to the actual (true) value (e.g. for accuracy +/- 5, write "5"). (ft)
+          Manufacturer provided specification of elevation accuracy of the sensor:
+          This is the accuracy uncertainty of the elevation measurement for the sensor.
+          Accuracy = how close a measured value is to the actual (true) value
+          (e.g. for accuracy +/- 5, write "5"). (ft)
         $ref: "#/definitions/feet"
 
   DaaSensorV2V:
@@ -317,7 +326,7 @@ definitions:
         $ref: "#/definitions/seconds"
       expectedClimbRateOwnship:
         description: >-
-          Expected Vehicle Climb Rates of the ownship used in the conflict
+          Expected Vehicle Climb Rate of the ownship used in the conflict
           resolution algorithm. (ft/s)
         $ref: "#/definitions/ftPerSec"
       expectedDescendRateOwnship:
@@ -358,8 +367,9 @@ definitions:
       azimuthAccuracyRealTime:
         description: >-
           Azimuth accuracy of the sensor (real time): uncertainty of the azimuth
-          measurement for the sensor. Accuracy = how close a measured value is
-          to the actual (true) value (e.g. for accuracy +/- 5, write "5"). (deg)
+          measurement for the sensor.
+          Accuracy = how close a measured value is to the actual (true) value
+          (e.g. for accuracy +/- 5, write "5"). (deg)
 
           Required if sensor is capable of capturing this data.
         $ref: '#/definitions/degrees'
@@ -376,8 +386,9 @@ definitions:
         description: >-
           Horizontal range accuracy of the sensor (real time). This is the
           accuracy or uncertainty of the horizontal range measurement for the
-          sensor. Accuracy = how close a measured value is to the actual (true)
-          value (e.g. for accuracy +/- 5, write "5"). (ft)
+          sensor.
+          Accuracy = how close a measured value is to the actual (true) value
+          (e.g. for accuracy +/- 5, write "5"). (ft)
 
           Required if sensor is capable of capturing this data.
         $ref: '#/definitions/feet'
@@ -516,7 +527,9 @@ definitions:
 
   DaaSensorObstacle:
     description: >-
-      Sensor detection of dynamic or static obstacles.  At each relevant timestamp, report the polygon that the sensor constructs as an estimate of the object.  Include an estimate of its height.
+      Sensor detection of dynamic or static obstacles.
+      At each relevant timestamp, report the polygon that the sensor constructs
+      as an estimate of the object.  Include an estimate of its height.
     required:
       - metaData
       - sensorId

--- a/TCL4 Data Management/utm-tcl4-dmp-daa.yaml
+++ b/TCL4 Data Management/utm-tcl4-dmp-daa.yaml
@@ -152,8 +152,14 @@ definitions:
         $ref: "#/definitions/feet"
 
       sensorMaxVertRange:
+        description: >-
+          Expected maximum relative vertical range as detected by a sensor in
+          the north east down reference frame of the ownship aircraft.
         $ref: "#/definitions/feet"
       sensorMinVertRange:
+        description: >-
+          Expected minimum relative vertical range as detected by a sensor in
+          the north east down reference frame of the ownship aircraft.
         $ref: "#/definitions/feet"
       maxVertRcsOfSensor:
         description: >-
@@ -219,6 +225,8 @@ definitions:
           A reference to a previously submitted DaaSensor via its sensorId.
         $ref: "#/definitions/DaaUuid"
       txRadioFrequencyV2V:
+        description: >-
+          Provide V2V Radio Frequency communication band (GHz).
         $ref: "#/definitions/gigaHertz"
       txRadioFrequencyPowerEirpV2V:
         description: >-
@@ -289,27 +297,50 @@ definitions:
         $ref: "#/definitions/seconds"
       expectedOperatorResponseTime:
         description: >-
+          Expected UAS Operator response time: temporal parameter used in the
+          conflict resolution algorithm to estimate the UAS Operators time
+          needed to initiate a resolution maneuver. Include 3 decimal places of
+          precision. (sec)
         $ref: "#/definitions/seconds"
       expectedUASResponseTime:
         description: >-
+          Expected Time for aircraft maneuver: temporal parameter used in the
+          conflict resolution algorithm to predict the time needed for the
+          aircraft to perform a resolution maneuver. Include 3 decimal places of
+          precision. (sec)
         $ref: "#/definitions/seconds"
       expectedCommLatency:
         description: >-
+          Total Expected Transmission Latency: total communication latency
+          expected in the conflict resolution (e.g. round-trip time). Include 3
+          decimal places of precision. (sec)
         $ref: "#/definitions/seconds"
       expectedClimbRateOwnship:
         description: >-
+          Expected Vehicle Climb Rates of the ownship used in the conflict
+          resolution algorithm. (ft/s)
         $ref: "#/definitions/ftPerSec"
       expectedDescendRateOwnship:
         description: >-
+          Expected Vehicle Descend Rate of the ownship used in the conflict
+          resolution algorithm. (ft/s)
         $ref: "#/definitions/ftPerSec"
       expectedTurnRateOwnship:
         description: >-
+          Expected Vehicle Turn Rate of the ownship used in the conflict
+          resolution algorithm. (deg/s)
         $ref: "#/definitions/degPerSec"
       expectedTimeToHover:
         description: >-
+          Expected time required for a vehicle to arrest forward motion and
+          hover at a position. (sec)
         $ref: "#/definitions/seconds"
       probabilityFalseAlarmPrct:
         description: >-
+          Manufacturer provided specification of probability of False Alarm:
+          the likelihood of an alert being issued that would result in no loss
+          of separation (if action was not taken).
+          Express in percentage, between 0 and 100.
         $ref: "#/definitions/percent"
 
   DaaSensorAccuracyRealTime:
@@ -325,12 +356,39 @@ definitions:
       timestamp:
         $ref: 'https://raw.githubusercontent.com/nasa/utm-docs/develop/TCL4%20Data%20Management/utm-tcl4-dmp-common.yaml#/definitions/timestamp'
       azimuthAccuracyRealTime:
+        description: >-
+          Azimuth accuracy of the sensor (real time): uncertainty of the azimuth
+          measurement for the sensor. Accuracy = how close a measured value is
+          to the actual (true) value (e.g. for accuracy +/- 5, write "5"). (deg)
+
+          Required if sensor is capable of capturing this data.
         $ref: '#/definitions/degrees'
       altitudeAccuracyRealTime:
+        description: >-
+          Elevation accuracy of the sensor (real time): This is the accuracy
+          uncertainty of the elevation measurement for the sensor.
+          Accuracy = how close a measured value is to the actual (true) value
+          (e.g. for accuracy +/- 5, write "5"). (ft)
+
+          Required if sensor is capable of capturing this data.
         $ref: '#/definitions/feet'
       horRangeAccuracyRealTime:
+        description: >-
+          Horizontal range accuracy of the sensor (real time). This is the
+          accuracy or uncertainty of the horizontal range measurement for the
+          sensor. Accuracy = how close a measured value is to the actual (true)
+          value (e.g. for accuracy +/- 5, write "5"). (ft)
+
+          Required if sensor is capable of capturing this data.
         $ref: '#/definitions/feet'
       verRangeAccuracyRealTime:
+        description: >-
+          Vertical range accuracy of the sensor (real time): uncertainty of the
+          vertical range measurement for the sensor.
+          Accuracy = how close a measured value is to the actual (true) value
+          (e.g. for accuracy +/- 5, write "5"). (ft)
+
+          Required if sensor is capable of capturing this data.
         $ref: '#/definitions/feet'
 
   DaaSensorV2vData:
@@ -348,10 +406,20 @@ definitions:
       timestamp:
         $ref: 'https://raw.githubusercontent.com/nasa/utm-docs/develop/TCL4%20Data%20Management/utm-tcl4-dmp-common.yaml#/definitions/timestamp'
       dataPacketRatioV2v:
+        description: >-
+          Packet Delivery/Reception Ratio: ratio of data-packets-received to
+          data-packets-sent between UA and UA (V2V).
         $ref: '#/definitions/ratio'
       transmissionDelayV2v:
+        description: >-
+          Transmission time delay associated with transmitting data packet
+          information from a source to a destination (V2V). Include 3 decimal
+          places of precision. (sec)
         $ref: "#/definitions/seconds"
       packetSizeV2v:
+        description: >-
+          Size of V2V data packet that is transmitted from a source transponder
+          (ownship) to a destination receiver (intruder). (kilobytes)
         $ref: '#/definitions/kiloBytes'
 
   DaaSensorNumberOfLostTracks:
@@ -368,6 +436,8 @@ definitions:
       timestamp:
         $ref: 'https://raw.githubusercontent.com/nasa/utm-docs/develop/TCL4%20Data%20Management/utm-tcl4-dmp-common.yaml#/definitions/timestamp'
       numberOfLostTracks:
+        description: >-
+          Number of established tracks lost at this timestamp.
         $ref: '#/definitions/count'
 
   DaaSensorTimeToTrack:
@@ -385,14 +455,22 @@ definitions:
       sensorId:
         $ref: "#/definitions/DaaUuid"
       firstDetectionTime:
+        description: >-
+          UTC time when first detection by the sensor occurred.
+
+          NOTE: 'firstDetectionTime' and 'timeRequiredForTrack' correspond to the SAME track.
         $ref: 'https://raw.githubusercontent.com/nasa/utm-docs/develop/TCL4%20Data%20Management/utm-tcl4-dmp-common.yaml#/definitions/timestamp'
       timeRequiredForTrack:
+        description: >-
+          UTC time when the sensor has established a track.
+
+          NOTE: 'firstDetectionTime' and 'timeRequiredForTrack' correspond to the SAME track.
         $ref: 'https://raw.githubusercontent.com/nasa/utm-docs/develop/TCL4%20Data%20Management/utm-tcl4-dmp-common.yaml#/definitions/timestamp'
 
   DaaSensorIntruderAircraftDetection:
     description: >-
-      Timestamp,Lat,Lon,Alt of intruder aircraft detected position(s)-DAA
-      (Detect And Avoid).  Include (uvin,gufi) of detected a/c
+      Timestamp,Lat,Lon,Alt of intruder aircraft detected position(s).
+      Include (uvin,gufi) of detected a/c.
     required:
       - metaData
       - sensorId
@@ -409,7 +487,7 @@ definitions:
         $ref: 'https://raw.githubusercontent.com/nasa/utm-docs/develop/TCL4%20Data%20Management/utm-tcl4-dmp-common.yaml#/definitions/timestamp'
       uvin:
         description: >-
-          UTM Vehicle Identifier
+          UTM Vehicle Identifier of the detected aircraft.
         type: string
         format: uuid
         maxLength: 36
@@ -418,12 +496,13 @@ definitions:
         example: "00000000-0000-4444-8888-FEEDDEADBEEF"
       gufi:
         description: >-
-          GUFI of the operation that is the source of these data. Note that this
-          GUFI is repeated in the Position model, so they must match.  In addition
-          this GUFI will map to operational data in the UTM data stores.  Thus
-          the values for call_sign, test_card, test_run must match the metadata
-          supplied with that Operation's metadata.  Mismatches will cause the
-          data submission to be rejected.
+          GUFI of the detected aircraft.
+
+          Note that this GUFI is repeated in the Position model, so they must
+          match. In addition this GUFI will map to operational data in the UTM
+          data stores. Thus the values for call_sign, test_card, test_run must
+          match the metadata supplied with that Operation's metadata. Mismatches
+          will cause the data submission to be rejected.
         type: string
         format: uuid
         maxLength: 36
@@ -431,6 +510,8 @@ definitions:
         pattern: "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[8-b][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
         example: "00000000-0000-4444-8888-FEEDDEADBEEF"
       latLonAlt:
+        description: >-
+          Location of intruder (Lat,Lon,Alt).
         $ref: '#/definitions/LatLonAlt'
 
   DaaSensorObstacle:
@@ -451,10 +532,19 @@ definitions:
       timestamp:
         $ref: 'https://raw.githubusercontent.com/nasa/utm-docs/develop/TCL4%20Data%20Management/utm-tcl4-dmp-common.yaml#/definitions/timestamp'
       obstaclePolygon:
+        description: >-
+          Time stamped (UTC) Lat/Lon list of the vertices of the polygons around
+          terrestrial dynamic obstacles in the environment.
+
+          Report at least seven decimal degrees. (deg)
         $ref: "#/definitions/LatLonArray"
       obstacleHeight:
         description: >-
-          height in ft
+          If 'STATIC' -> Static obstacle altitude express in the WGS84
+          reference frame. (ft)
+
+          If 'DYNAMIC' -> Maximum height (difference between the
+          highest and the lowest dimensional point) of the dynamic obstacle. (ft)
         type: number
         minimum: 0
       obstacleType:
@@ -478,11 +568,15 @@ definitions:
         $ref: 'https://raw.githubusercontent.com/nasa/utm-docs/develop/TCL4%20Data%20Management/utm-tcl4-dmp-common.yaml#/definitions/metaData'
       conflictGufi:
         description: >-
-          "The GUFI of the vehicle in conflict with ownship"
+          The GUFI of the vehicle in conflict with ownship.
+
+          Required if in conflict with another aircraft.
         $ref: "#/definitions/DaaUuid"
       conflictUvin:
         description: >-
-          "The UVIN of the vehicle in conflict with ownship"
+          The UVIN of the vehicle in conflict with ownship.
+
+          Required if in conflict with another aircraft.
         $ref: "#/definitions/DaaUuid"
       typeOfConflictResolution:
         description: >-
@@ -509,9 +603,9 @@ definitions:
           properties:
             eventType:
               description: >-
-                timeAtEncounterInit	UTC time at Encounter Initiation.
-                timeAtEncounterEnd	UTC Time at Encounter End.
-                timeAtConflictAlert	UTC time at which a conflict alert is issued to a UAS Operator/UAS.
+                timeAtEncounterInit	- UTC time at Encounter Initiation.
+                timeAtEncounterEnd	- UTC Time at Encounter End.
+                timeAtConflictAlert	- UTC time at which a conflict alert is issued to a UAS Operator/UAS.
                 timeAtConflictResNoManeuverDecided - UTC time at which vehicle decides not to make a maneuver
                 timeAtConflictResHeadingChangeInit - UTC time at which vehicle begins heading change to resolve conflict.
                 timeAtConflictResHeadingChangeCmplt - UTC time at which vehicle completes heading change to resolve conflict.
@@ -525,11 +619,14 @@ definitions:
                 timeAtConflictResAddedWaypointCmplt - UTC time at which vehicle ends adding waypoint to resolve conflict.
                 timeAtConflictResOtherInit - UTC time at which vehicle begins other maneuver to resolve conflict.
                 timeAtConflictResOtherCmplt - UTC time at which vehicle ends other maneuver to resolve conflict.
-                timeAtClearOfConflict	UTC time at which the aircraft/UAS Operator declares the aircraft is clear of the conflict.
-                ussDaaAlertReceived	UTC time when a DAA alert issued from the USS is received by the operator.
-                onboardDaaAlertIssued	UTC time when a DAA alert is issued onboard the UAS.
-                groundDaaAlertIssued	UTC time when a DAA alert is issued from the ground DAA system.
-                caAlertIssued	UTC time when an alert is issued from the CA system.
+                timeAtClearOfConflict	- UTC time at which the aircraft/UAS Operator declares the aircraft is clear of the conflict.
+                ussDaaAlertReceived	- UTC time when a DAA alert issued from the USS is received by the operator.
+                onboardDaaAlertIssued	- UTC time when a DAA alert is issued onboard the UAS.
+                groundDaaAlertIssued - UTC time when a DAA alert is issued from the ground DAA system.
+                caAlertIssued	- UTC time when an alert is issued from the CA system.
+                ussCaAlertReceived - UTC time when a CA alert issued from the USS is received by the operator.
+                oaAlertIssued - UTC time when an alert is issued from the Obstacle Avoidance system (OA).
+                ussOaAlertReceived - UTC time when an OA alert issued from the USS is received by the operator.
               type: string
               enum:
                 - timeAtEncounterInit
@@ -678,6 +775,8 @@ definitions:
         type: number
         format: float
       polygonPoints:
+        description: >-
+          The first point and the last point must be equal.
         type: array
         items:
           $ref: "#/definitions/LatLon"
@@ -735,6 +834,9 @@ definitions:
 
       If used to describe a Polygon, the first point and the last point must
       be equal.
+
+      Latitude, Longitude, Altitude should have precision of 7 or more digits.
+      Report altitude in WGS84. (ft)
     type: array
     items:
       $ref: '#/definitions/LatLonAlt'
@@ -745,6 +847,8 @@ definitions:
 
       If used to describe a Polygon, the first point and the last point must
       be equal.
+
+      Latitude, Longitude, Altitude should have precision of 7 or more digits.
     type: array
     items:
       $ref: '#/definitions/LatLon'

--- a/TCL4 Data Management/utm-tcl4-dmp-fet-latency.yaml
+++ b/TCL4 Data Management/utm-tcl4-dmp-fet-latency.yaml
@@ -51,7 +51,10 @@ paths:
 definitions:
   SensorLatencyTuple:
     description: >-
-      Sensor latency tuple for a particular sensor measurement.  Report the time that the sensor measurement was sent from the UA and the time that the sensor measurement was received by the GCS.  Report  only for the data listed in the dmp fet requirements list. 
+      Sensor latency tuple for a particular sensor measurement.  Report the time
+      that the sensor measurement was sent from the aircraft and the time that
+      the sensor measurement was received by the GCS.  Report  only for the data
+      listed in the dmp fet requirements list.
     required:
       - sensor
       - time_sent
@@ -59,7 +62,7 @@ definitions:
     properties:
       time_sent:
         description: >-
-          Time sensor measurement was sent by UA
+          Time sensor measurement was sent by aircraft.
         type: string
         format: date-time
         minLength: 24
@@ -68,7 +71,7 @@ definitions:
         example: '2015-08-20T14:11:56.118Z'
       time_received:
         description: >-
-          Time sensor measurement was received by GCS.
+          Time sensor measurement was received by: GCS (if UA) or DAA system (if crewed).
         type: string
         format: date-time
         minLength: 24
@@ -76,12 +79,15 @@ definitions:
         pattern: "^([0-9]{4})-(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9])T(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])(\\.[0-9]{3})Z$"
         example: '2015-08-20T14:11:56.118Z'
       sensor:
+        description: >-
+          Refer to DMP for individual definitions of each of these sensors.
         $ref: 'https://raw.githubusercontent.com/nasa/utm-docs/develop/TCL4%20Data%20Management/utm-tcl4-dmp-common.yaml#/definitions/SensorList'
+
   FlightEssentialTelemetryLatency:
     description: >-
       Flight essential telemetry latency measurements.
-      TCL4. Refer to the DMP documentation on specific requirements for a given
-      run.
+      Use this model for both UAS and crewed vehicles.
+      Refer to the DMP documentation on specific requirements for a given run.
     required:
       - metaData
       - sensorLatencyTuple
@@ -90,8 +96,7 @@ definitions:
         $ref: 'https://raw.githubusercontent.com/nasa/utm-docs/develop/TCL4%20Data%20Management/utm-tcl4-dmp-common.yaml#/definitions/metaData'
       sensorLatencyTupleArray:
         description: >-
-          An array of sensor latency samples.  Note that the types of samples can be
-          mixed in this array.  
+          An individual sensor latency sample: sensor, time_sent, & time_received
         type: array
         items:
           $ref: '#/definitions/SensorLatencyTuple'
@@ -115,7 +120,7 @@ definitions:
           $ref: '#/definitions/SensorDoubleLatency'
         minItems: 1
         maxItems: 10000
-        
+
   SensorDoubleLatency:
     description: >-
       Sensor double latency
@@ -133,4 +138,4 @@ definitions:
         pattern: "^([0-9]{4})-(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9])T(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])(\\.[0-9]{3})Z$"
         example: '2015-08-20T14:11:56.118Z'
       sensor:
-        $ref: 'https://raw.githubusercontent.com/nasa/utm-docs/develop/TCL4%20Data%20Management/utm-tcl4-dmp-common.yaml#/definitions/SensorList'        
+        $ref: 'https://raw.githubusercontent.com/nasa/utm-docs/develop/TCL4%20Data%20Management/utm-tcl4-dmp-common.yaml#/definitions/SensorList'

--- a/TCL4 Data Management/utm-tcl4-dmp-fet-latency.yaml
+++ b/TCL4 Data Management/utm-tcl4-dmp-fet-latency.yaml
@@ -49,6 +49,26 @@ paths:
             when there are no paths, but domains do not contain paths.
 
 definitions:
+  FlightEssentialTelemetryLatency:
+    description: >-
+      Flight essential telemetry latency measurements.
+      Use this model for both UAS and crewed vehicles.
+      Refer to the DMP documentation on specific requirements for a given run.
+    required:
+      - metaData
+      - sensorLatencyTuple
+    properties:
+      metaData:
+        $ref: 'https://raw.githubusercontent.com/nasa/utm-docs/develop/TCL4%20Data%20Management/utm-tcl4-dmp-common.yaml#/definitions/metaData'
+      sensorLatencyTupleArray:
+        description: >-
+          An individual sensor latency sample: sensor, time_sent, & time_received
+        type: array
+        items:
+          $ref: '#/definitions/SensorLatencyTuple'
+        minItems: 1
+        maxItems: 10000
+
   SensorLatencyTuple:
     description: >-
       Sensor latency tuple for a particular sensor measurement.  Report the time
@@ -82,26 +102,6 @@ definitions:
         description: >-
           Refer to DMP for individual definitions of each of these sensors.
         $ref: 'https://raw.githubusercontent.com/nasa/utm-docs/develop/TCL4%20Data%20Management/utm-tcl4-dmp-common.yaml#/definitions/SensorList'
-
-  FlightEssentialTelemetryLatency:
-    description: >-
-      Flight essential telemetry latency measurements.
-      Use this model for both UAS and crewed vehicles.
-      Refer to the DMP documentation on specific requirements for a given run.
-    required:
-      - metaData
-      - sensorLatencyTuple
-    properties:
-      metaData:
-        $ref: 'https://raw.githubusercontent.com/nasa/utm-docs/develop/TCL4%20Data%20Management/utm-tcl4-dmp-common.yaml#/definitions/metaData'
-      sensorLatencyTupleArray:
-        description: >-
-          An individual sensor latency sample: sensor, time_sent, & time_received
-        type: array
-        items:
-          $ref: '#/definitions/SensorLatencyTuple'
-        minItems: 1
-        maxItems: 10000
 
   MetaDataCallSignRunTsSensorLatency:
     description: >-

--- a/TCL4 Data Management/utm-tcl4-dmp-fet-latency.yaml
+++ b/TCL4 Data Management/utm-tcl4-dmp-fet-latency.yaml
@@ -53,7 +53,8 @@ definitions:
     description: >-
       Flight essential telemetry latency measurements.
       Use this model for both UAS and crewed vehicles.
-      Refer to the DMP documentation on specific requirements for a given run.
+      Refer to DMP to identify which data are required for UAS vs. crewed and for
+      more specific requirements.
     required:
       - metaData
       - sensorLatencyTuple
@@ -92,6 +93,7 @@ definitions:
       time_received:
         description: >-
           Time sensor measurement was received by: GCS (if UA) or DAA system (if crewed).
+          See DMP for more detailed description.
         type: string
         format: date-time
         minLength: 24

--- a/TCL4 Data Management/utm-tcl4-dmp-fet.yaml
+++ b/TCL4 Data Management/utm-tcl4-dmp-fet.yaml
@@ -50,6 +50,26 @@ paths:
 
 definitions:
 
+  FlightEssentialTelemetryAndUasStates:
+    description: >-
+      Flight essential telemetry and UAS state data.
+      Use this model for both UAS and crewed vehicles.
+      Refer to DMP to identify which data are required for UAS vs. crewed.
+    required:
+      - metaData
+      - sensorTuple
+    properties:
+      metaData:
+        $ref: 'https://raw.githubusercontent.com/nasa/utm-docs/develop/TCL4%20Data%20Management/utm-tcl4-dmp-common.yaml#/definitions/metaData'
+      sensorTuple:
+        description: >-
+          An individual sensor sample: timestamp, sensor, & value
+        type: array
+        items:
+          $ref: '#/definitions/SensorTuple'
+        minItems: 1
+        maxItems: 10000
+
   SensorTuple:
     description: >-
       An individual sample of a sensor.  See DMP spreadsheet for definitions of
@@ -84,26 +104,6 @@ definitions:
         description: >-
           Refer to DMP for individual definitions and units of each of these sensors.
         $ref: 'https://raw.githubusercontent.com/nasa/utm-docs/develop/TCL4%20Data%20Management/utm-tcl4-dmp-common.yaml#/definitions/SensorList'
-
-  FlightEssentialTelemetryAndUasStates:
-    description: >-
-      Flight essential telemetry and UAS state data.
-      Use this model for both UAS and crewed vehicles.
-      Refer to DMP to identify which data are required for UAS vs. crewed.
-    required:
-      - metaData
-      - sensorTuple
-    properties:
-      metaData:
-        $ref: 'https://raw.githubusercontent.com/nasa/utm-docs/develop/TCL4%20Data%20Management/utm-tcl4-dmp-common.yaml#/definitions/metaData'
-      sensorTuple:
-        description: >-
-          An individual sensor sample: timestamp, sensor, & value
-        type: array
-        items:
-          $ref: '#/definitions/SensorTuple'
-        minItems: 1
-        maxItems: 10000
 
   MetaDataCallSignRunTsSensor:
     description: >-

--- a/TCL4 Data Management/utm-tcl4-dmp-fet.yaml
+++ b/TCL4 Data Management/utm-tcl4-dmp-fet.yaml
@@ -56,6 +56,11 @@ definitions:
       the various enum values.
 
       Each sensor will have its own requirements on sample frequency.
+
+      NOTE: If 'sensor' = "AIRCRAFT_AIRBORNE_STATE_NONDIM" then 'value' = 0 or 1
+      0 = on ground
+      1 = in air
+      Report at least 1 Hz frequency.
     required:
       - timestamp
       - sensor
@@ -73,15 +78,18 @@ definitions:
       value:
         type: number
         format: double
-        description: value of sensor reading
+        description: >-
+          Value of sensor reading.
       sensor:
+        description: >-
+          Refer to DMP for individual definitions and units of each of these sensors.
         $ref: 'https://raw.githubusercontent.com/nasa/utm-docs/develop/TCL4%20Data%20Management/utm-tcl4-dmp-common.yaml#/definitions/SensorList'
 
   FlightEssentialTelemetryAndUasStates:
     description: >-
-      Flight essential telemetry and UAS state data for a UAS Operation in
-      TCL4. Refer to the DMP documentation on specific requirements for a given
-      run.  Use this model for crewed vehicles as well.  
+      Flight essential telemetry and UAS state data.
+      Use this model for both UAS and crewed vehicles.
+      Refer to DMP to identify which data are required for UAS vs. crewed.
     required:
       - metaData
       - sensorTuple
@@ -90,9 +98,7 @@ definitions:
         $ref: 'https://raw.githubusercontent.com/nasa/utm-docs/develop/TCL4%20Data%20Management/utm-tcl4-dmp-common.yaml#/definitions/metaData'
       sensorTuple:
         description: >-
-          An array of sensor samples.  Note that the types of samples can be
-          mixed in this array.  Also, since time is an element of the sample,
-          the samples can be from any variety of times.
+          An individual sensor sample: timestamp, sensor, & value
         type: array
         items:
           $ref: '#/definitions/SensorTuple'
@@ -110,7 +116,7 @@ definitions:
         $ref: 'https://raw.githubusercontent.com/nasa/utm-docs/develop/TCL4%20Data%20Management/utm-tcl4-dmp-common.yaml#/definitions/MetaDataCallSignRun'
       sensor_double:
         description: >-
-          An array of SensorDouble models to delete
+          An array of SensorDouble models to delete.
         type: array
         items:
           $ref: '#/definitions/SensorDouble'
@@ -119,6 +125,7 @@ definitions:
 
   SensorDouble:
     description: >-
+      An array of models to delete.
     required:
       - timestamp
       - sensor
@@ -133,6 +140,4 @@ definitions:
         pattern: "^([0-9]{4})-(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9])T(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])(\\.[0-9]{3})Z$"
         example: '2015-08-20T14:11:56.118Z'
       sensor:
-        $ref: '#/definitions/SensorList'
-
-      
+        $ref: 'https://raw.githubusercontent.com/nasa/utm-docs/develop/TCL4%20Data%20Management/utm-tcl4-dmp-common.yaml#/definitions/SensorList'


### PR DESCRIPTION
These changes are based on the description updates/additions discussions the DMP has been discussing.
This also addressed Jaewoo's request for capturing that 'time_occurance' should be required for all OffNominalReport submissions (added description to reflect this requirement, no changes were made to the "required" elements list).
Also, reorganized fet and fet-latency so the primary data models are at the top.

Please review all 3 commits individually.

Thank you,
Brandon