### PR TITLE
Adding enum of "OTHER" to DynamicRestrictionOccurence

### DIFF
--- a/TCL4 Data Management/utm-tcl4-data-collection.yaml
+++ b/TCL4 Data Management/utm-tcl4-data-collection.yaml
@@ -632,6 +632,7 @@ definitions:
           - WEBSOCKETS
           - EMAIL
           - SMS
+          - OTHER
       message_to_operator:
         description: >-
           The actual data payload sent to the operator from the USS. May be


### PR DESCRIPTION
Adding enum of "OTHER" to "message_protocol" within DynamicRestrictionOccurrence. In the description, we state for them to select 'OTHER' if not in the list, but was not an option.